### PR TITLE
Drop Linux build distribution

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -31,8 +31,8 @@ jobs:
         include:
           - platform: "windows-latest"
             args: ""
-          - platform: "ubuntu-22.04"
-            args: ""
+        #   - platform: "ubuntu-22.04"
+        #     args: ""
           - platform: "macos-latest" # for Arm based macs (M1 and above).
             args: "--target aarch64-apple-darwin"
           - platform: "macos-latest" # for Intel based macs.
@@ -53,11 +53,11 @@ jobs:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-      - name: install libs
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+    #   - name: install libs
+    #     if: matrix.platform == 'ubuntu-22.04'
+    #     run: |
+    #       sudo apt-get update
+    #       sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install frontend libs
         run: |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For macOS, you can get `.dmg` file to install.
 
 ### Linux
 
-For Linux, you can get `.deb`, `.rpm` or `.AppImage` file to install.
+Binary distributions for Linux are not currently provided.
 
 ## config.json
 
@@ -39,7 +39,8 @@ The `config.json` file should be located in the following directories:
 
 * Windows: `C:\Users\{USER}\AppData\Roaming\com.bayashi.mclocks\`
 * Mac: `/Users/{USER}/Library/Application Support/com.bayashi.mclocks/`
-* Linux: `/home/{USER}/.config/com.bayashi.mclocks/`
+
+<!-- * Linux: `/home/{USER}/.config/com.bayashi.mclocks/` -->
 
 When you start `mclocks`, then press `Ctrl + o` to edit your `config.json` file.
 


### PR DESCRIPTION
Since the author does not have a Linux desktop environment, we have stopped distributing Linux builds to reduce CI build time.

If you need a Linux binary, you can fork the repository and slightly modify the workflow. If you manage to get it working, I’d appreciate it if you could let me know. (It’s unlikely to work correctly out of the box.)